### PR TITLE
CVE-2018-14574

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.3
 dj-database-url==0.4.2
-Django==1.11
+Django==1.11.15
 django-environ==0.4.3
 django-extensions==1.7.8
 gunicorn==19.7.1


### PR DESCRIPTION
Vulnerable versions: >= 1.11.0, < 1.11.15
Patched version: 1.11.15
django.middleware.common.CommonMiddleware in Django 1.11.x before 1.11.15 and 2.0.x before 2.0.8 has an Open Redirect.

CVE Details:
* https://nvd.nist.gov/vuln/detail/CVE-2018-14574