### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-extensions==1.7.8
 gunicorn==19.7.1
 olefile==0.44
 packaging==16.8
-Pillow==6.2.0
+Pillow==6.2.2
 psycopg2==2.7.1
 pyparsing==2.2.0
 pytz==2017.2


### PR DESCRIPTION
CVE-2019-19911
moderate severity
Vulnerable versions: < 6.2.2
Patched version: 6.2.2

There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer.
